### PR TITLE
Não deve somar valor de IPI na Base de Calculo de ICMS

### DIFF
--- a/src/main/java/com/chronos/calc/calculos/base/CalcularBaseICMS.java
+++ b/src/main/java/com/chronos/calc/calculos/base/CalcularBaseICMS.java
@@ -41,8 +41,7 @@ public class CalcularBaseICMS extends CalcularBaseCalculoBase {
 
     @Override
     public BigDecimal getBaseCalculo() {
-        BigDecimal baseCalculo = super.getBaseCalculo()
-                .add(Optional.ofNullable(getTributos().getValorIpi()).orElse(BigDecimal.ZERO));
+        BigDecimal baseCalculo = super.getBaseCalculo();
         return aplicarReducaoBaseCalculo(baseCalculo);
     }
 


### PR DESCRIPTION
Não deve somar valor de IPI na Base de Calculo de ICMS, somente na base de ST como já faz hoje